### PR TITLE
Fix: Prevent double response in media route

### DIFF
--- a/src/backend/src/main/kotlin/org/icpclive/Application.kt
+++ b/src/backend/src/main/kotlin/org/icpclive/Application.kt
@@ -92,11 +92,11 @@ fun Application.module() {
                 val file = dir.combineSafe(relativePath)
                 if (file.isDirectory) {
                     call.respond(file.listFiles()?.map { "/${file.path}/${it.name}" } ?: emptyList())
-                }
-                if (file.isFile) {
+                } else if (file.isFile) {
                     call.respondFile(file)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
                 }
-                call.respond(HttpStatusCode.NotFound)
             }
         }
         singlePageApplication {


### PR DESCRIPTION
This PR fixes a bug in the `/media` route where the server could attempt to send two responses to a single request.

The original code had two consecutive `if` statements. If the first `if` condition was true, a response would be sent. However, the code would continue to the next `if` statement and then to the final `call.respond`, which would cause a crash.

This PR changes the logic to an `if-else if-else` structure, ensuring that only one response is sent.

---
*This pull request was generated by Gemini without human interaction.*

![A cat](https://placecats.com/300/200)